### PR TITLE
Edit an Event from Mobile

### DIFF
--- a/index.php
+++ b/index.php
@@ -291,7 +291,7 @@ $events = $req->fetchAll();
 			},
 	
 			eventRender: function(event, element) {
-				element.bind('dblclick', function() {
+				element.bind('click', function() {
 					$('#ModalEdit #id').val(event.id);
 					$('#ModalEdit #title').val(event.title);
 					$('#ModalEdit #description').val(event.description);


### PR DESCRIPTION
I've replaced '**dblclick**' with '**click**' on eventRender: function() because of double click on mobile browser was not recognized.